### PR TITLE
Don't use free variable

### DIFF
--- a/ghost-mode.el
+++ b/ghost-mode.el
@@ -165,7 +165,8 @@
 ;; Metadata
 (defun ghost-mode--get-metadata-as-string (post)
   "Get list of POST metadata as a string."
-  (let ((metadata ghost-mode--metadata-prefix))
+  (let ((metadata ghost-mode--metadata-prefix)
+	current-value)
     (dolist (metadata-field ghost-mode-default-metadata-fields)
       (setq current-value (gethash (symbol-name metadata-field) post))
 


### PR DESCRIPTION
This PR fixes following byte-compile warnings.

```
In ghost-mode--get-metadata-as-string:
ghost-mode.el:172:25:Warning: assignment to free variable ‘current-value’
ghost-mode.el:173:17:Warning: reference to free variable ‘current-value’
```
